### PR TITLE
Feature: Make interface selectable in local Static File Server (Electron) mode

### DIFF
--- a/apps/desktop/src/ipc.ts
+++ b/apps/desktop/src/ipc.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import { Logger } from './logger';
 import { staticServerManager } from './staticServerManager';
 import { storeManager } from './store';
+import { updater } from './updater';
 import { getAvailableInterfaces, getIp } from './utils';
 
 export class Ipc {

--- a/apps/desktop/src/ipc.ts
+++ b/apps/desktop/src/ipc.ts
@@ -5,8 +5,7 @@ import fs from 'fs';
 import { Logger } from './logger';
 import { staticServerManager } from './staticServerManager';
 import { storeManager } from './store';
-import { updater } from './updater';
-import { getIp } from './utils';
+import { getAvailableInterfaces, getIp } from './utils';
 
 export class Ipc {
   static win: BrowserWindow;
@@ -56,13 +55,13 @@ export class Ipc {
       event.returnValue = filePaths[0];
     });
 
-    ipcMainHandle('createStaticFileServer', async (_, { directoryPath, port }) => {
+    ipcMainHandle('createStaticFileServer', async (_, { directoryPath, port, preferredInterface }) => {
       try {
         const res = await staticServerManager.createServer({ directoryPath, port });
-        const ip = getIp();
+        const ip = preferredInterface ?? getIp();
         if (res && ip) {
           return {
-            url: `http://${getIp()}:${port}`
+            url: `http://${ip}:${port}`
           };
         }
       } catch (err) {
@@ -70,6 +69,22 @@ export class Ipc {
           errorMessage: `Create WebDAV server failed: ${(err as Error).message}`
         };
       }
+    });
+
+    ipcMainHandle('getAvailableInterfaces', async () => {
+      try {
+        const ifaces = getAvailableInterfaces();
+        if (ifaces) {
+          return ifaces.map(ifc => {
+            return { ipv4: ifc?.address || '' };
+          });
+        }
+      } catch (err) {
+        return {
+          errorMessage: `Get AvailableInterfaces failed: ${(err as Error).message}`
+        };
+      }
+      return [];
     });
 
     ipcMainHandle('getPath', async (_, path) => {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -22,10 +22,11 @@ export const preload = () => {
     openExternal: url => shell.openExternal(url),
     getPath: path => ipcRendererInvoke('getPath', path),
     getAppInfo: () => ipcRendererInvoke('getAppInfo'),
-    openDirectoryDialog: () => ipcRendererSendSync('openDirectoryDialog'),
-    createStaticFileServer: ({ directoryPath, port }) =>
-      ipcRendererInvoke('createStaticFileServer', { directoryPath, port }),
     openDevTools: () => ipcRendererInvoke('openDevTools'),
+    createStaticFileServer: ({ directoryPath, port, preferredInterface }) =>
+      ipcRendererInvoke('createStaticFileServer', { directoryPath, port, preferredInterface }),
+    openDirectoryDialog: () => ipcRendererSendSync('openDirectoryDialog'),
+    getAvailableInterfaces: () => ipcRendererInvoke('getAvailableInterfaces'),
     openAppLog: () => ipcRendererInvoke('openAppLog'),
     checkUpdate: () => ipcRendererInvoke('checkUpdate')
   };

--- a/apps/desktop/src/utils.ts
+++ b/apps/desktop/src/utils.ts
@@ -5,3 +5,9 @@ export const getIp = () => {
     .flat()
     .find(i => i?.family == 'IPv4' && !i?.internal)?.address;
 };
+
+export const getAvailableInterfaces = () => {
+  return Object.values(networkInterfaces())
+    .flat()
+    .filter(i => i?.family == 'IPv4' && !i?.internal && i.address != '');
+};

--- a/apps/web/src/components/ConfigCard.module.less
+++ b/apps/web/src/components/ConfigCard.module.less
@@ -25,6 +25,10 @@
     flex-shrink: 0;
     margin-left: 10px;
   }
+  .subTitle {
+    color: var(--gray-3);
+    font-size: smaller;
+  }
 }
 
 .action-icon-wrapper {

--- a/apps/web/src/components/ConfigCard.tsx
+++ b/apps/web/src/components/ConfigCard.tsx
@@ -1,3 +1,4 @@
+import { Typography } from '@arco-design/web-react';
 import cs from 'classnames';
 import React, { ReactNode } from 'react';
 
@@ -9,6 +10,7 @@ type Props = {
   isActive?: boolean;
   action?: ReactNode;
   onClick?: () => void;
+  subTitle?: string;
 };
 
 const ActionIcon = (props: { children: ReactNode; onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void }) => {
@@ -25,7 +27,7 @@ const ActionIcon = (props: { children: ReactNode; onClick?: (event: React.MouseE
   );
 };
 
-export const ConfigCard = ({ title, action, isActive, onClick }: Props) => {
+export const ConfigCard = ({ title, action, isActive, onClick, subTitle }: Props) => {
   return (
     <div
       className={cs(styles.wrapper, isActive && styles.active)}
@@ -37,6 +39,15 @@ export const ConfigCard = ({ title, action, isActive, onClick }: Props) => {
         <Link canceldUnderline={true} hoverable={false}>
           {title}
         </Link>
+        {subTitle ? (
+          <Typography.Paragraph
+            ellipsis={{ rows: 1 }}
+            style={{ marginTop: 1, marginBottom: 0 }}
+            className={styles.subTitle}
+          >
+            {subTitle}
+          </Typography.Paragraph>
+        ) : null}
       </div>
       {action && <div className={styles.action}>{action}</div>}
     </div>

--- a/apps/web/src/pages/Hosts/components/FileServerFormModal.tsx
+++ b/apps/web/src/pages/Hosts/components/FileServerFormModal.tsx
@@ -32,6 +32,8 @@ export const FileServerFormModal = ({ data, visible, onCancel, onOk }: Props) =>
     window.electron ? FileServerType.StaticFileServer : FileServerType.WebDAV
   );
 
+  const [protocol, setProtocol] = useState<'http://' | 'https://'>('http://');
+
   const [form] = Form.useForm<FormData>();
 
   const {
@@ -41,6 +43,8 @@ export const FileServerFormModal = ({ data, visible, onCancel, onOk }: Props) =>
   const handleCancel = () => {
     onCancel();
     setCreateType(window.electron ? FileServerType.StaticFileServer : FileServerType.WebDAV);
+    form.resetFields(undefined);
+    setProtocol('http://');
     form.resetFields();
   };
 
@@ -51,7 +55,8 @@ export const FileServerFormModal = ({ data, visible, onCancel, onOk }: Props) =>
     if (data?.id && data?.type) {
       setCreateType(data.type);
     }
-    console.log(data);
+    setProtocol(data.url.startsWith('https://') ? 'https://' : 'http://');
+    data.url = data.url.replace(/^https?:\/\//g, '');
     form.setFieldsValue(data);
   }, [data]);
 
@@ -84,6 +89,9 @@ export const FileServerFormModal = ({ data, visible, onCancel, onOk }: Props) =>
       return;
     }
     try {
+      if (value.url) {
+        value.url = protocol + value.url.trim().replace(/\/$/, '');
+      }
       if (createType === FileServerType.StaticFileServer) {
         if (value.url) {
           try {
@@ -178,7 +186,15 @@ export const FileServerFormModal = ({ data, visible, onCancel, onOk }: Props) =>
             rules={[{ required: true, message: 'Please input url' }]}
             extra="For example: http://example.com"
           >
-            <Input />
+            <Input
+              autoFocus
+              addBefore={
+                <Select value={protocol} style={{ width: 100 }} onChange={setProtocol}>
+                  <Select.Option value="http://">http://</Select.Option>
+                  <Select.Option value="https://">https://</Select.Option>
+                </Select>
+              }
+            />
           </FormItem>
         )}
         {createType === FileServerType.StaticFileServer ? (
@@ -219,4 +235,3 @@ export const FileServerFormModal = ({ data, visible, onCancel, onOk }: Props) =>
     </Modal>
   );
 };
-

--- a/apps/web/src/pages/Hosts/components/FileServerHost.tsx
+++ b/apps/web/src/pages/Hosts/components/FileServerHost.tsx
@@ -52,7 +52,8 @@ export const FileServerHost = () => {
       setFormData({
         ...commonData,
         directoryPath: host?.directoryPath,
-        port: host.port
+        port: host.port,
+        iface: host.preferredInterface
       });
     }
   };
@@ -70,7 +71,11 @@ export const FileServerHost = () => {
       setIsFileServerReady(false);
       if (host.type === FileServerType.StaticFileServer && window.electron) {
         setLoading(true);
-        await window.electron.createStaticFileServer({ directoryPath: host.directoryPath, port: host.port });
+        await window.electron.createStaticFileServer({
+          directoryPath: host.directoryPath,
+          port: host.port,
+          preferredInterface: host.preferredInterface
+        });
       }
       setIsFileServerReady(true);
     } catch (err) {
@@ -102,7 +107,8 @@ export const FileServerHost = () => {
         ...commonData,
         type: value.type,
         directoryPath: value.directoryPath as string,
-        port: value.port as number
+        port: value.port as number,
+        preferredInterface: value.iface
       };
     }
     const cur = fileServerHosts.find(item => item.id === value.id);
@@ -134,6 +140,7 @@ export const FileServerHost = () => {
               key={host.id}
               title={host.alias || host.url}
               isActive={host.id === curFileServerHostId}
+              subTitle={'preferredInterface' in host ? host.preferredInterface : ''}
               onClick={() => handleChangeHost(host)}
               action={
                 <Space size={3}>

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -27,6 +27,8 @@ export type StaticFileServerHost = {
   directoryPath: string;
   port: number;
   url: string;
+
+  preferredInterface?: string;
 };
 
 export type FileServerHost = WebDAVHost | StaticFileServerHost;

--- a/packages/common/types/electronApi.ts
+++ b/packages/common/types/electronApi.ts
@@ -16,13 +16,14 @@ export interface IElectronIpcMainHandles {
     path: string;
   }>;
   openDirectoryDialog: () => Promise<string | undefined>;
-  createStaticFileServer: (params: { directoryPath: string; port: number }) => Promise<
+  createStaticFileServer: (params: { directoryPath: string; port: number; preferredInterface?: string }) => Promise<
     | {
         url?: string;
         errorMessage?: string;
       }
     | undefined
   >;
+  getAvailableInterfaces: () => Promise<{ ipv4: string }[] | { errorMessage?: string } | null>;
   openDevTools: () => void;
   openAppLog: () => void;
   checkUpdate: () => void;


### PR DESCRIPTION
Hello there
Thanks a lot for your work!

I'm here just to drop a feature that I find kinda useful in my laptop network config

As NodeJS `networkInterfaces` (and the subsequent `Object.values(networkInterfaces())`) enumerates the available interfaces, It is possible that the order in which the latter are returned may vary (eg. When disconnecting the integrated Wifi card and then plugging an external ethernet dongle adapter, or even the simple desire to route bind the server via a more suitable adapter (cable FTW))



This PR implements both the choice inside `FileServerFormModal`, in a non-breaking way (At least, I tried to make it so) (It's non mandatory defaulting as it was (first interface found)) 
<img width="523" alt="Schermata 2022-04-10 alle 19 36 06" src="https://user-images.githubusercontent.com/2205037/162632067-04b47206-e1e5-4b36-a747-bd0258ce9fe2.png">

and the display for the "current" used adapter (IP) inside the `ConfigCard` component
<img width="287" alt="Schermata 2022-04-10 alle 19 34 44" src="https://user-images.githubusercontent.com/2205037/162632013-81f31c5f-0b45-4e79-913e-639e36ffd50a.png">


Thanks again!
 